### PR TITLE
Remove webpack resolver

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,5 @@ module.exports = {
         ]
       }
     ]
-  },
-  settings: { 'import/resolver': { webpack: {} } }
+  }
 };


### PR DESCRIPTION
The webpack import resolver makes the assumption that every project using this config is also using webpack.
This is not necessarily the case, and should be up to the final inheriting project to set this setting.